### PR TITLE
Remove log namespace and update use of context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: audit test build
 
 .PHONY: audit
 audit:
-	go list -json -m all | nancy sleuth --exclude-vulnerability-file ./.nancy-ignore
+	go list -json -m all | nancy sleuth
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -50,19 +50,21 @@ import (
 )
 
 func TestExample(t *testing.T) {
+	testCtx := context.Background()
+
 	server, err := mim.Start("5.0.2")
 	if err != nil {
 		// Deal with error
 	}
 	defer server.Stop()
 
-	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(server.URI()))
+	client, err := mongo.Connect(testCtx, options.Client().ApplyURI(server.URI()))
 	if err != nil {
 		// Deal with error
 	}
 
 	//Use client as needed
-	client.Ping(context.Background(), nil)
+	client.Ping(testCtx, nil)
 }
 
 ```

--- a/download/config.go
+++ b/download/config.go
@@ -40,7 +40,7 @@ type Config struct {
 // NewConfig creates the config values for the given version.
 // It will identify the appropriate mongodb artifact
 // and the cache path based on the current OS
-func NewConfig(mongoVersionStr string) (*Config, error) {
+func NewConfig(ctx context.Context, mongoVersionStr string) (*Config, error) {
 	version, versionErr := NewVersion(mongoVersionStr)
 	if versionErr != nil {
 		return nil, versionErr
@@ -51,7 +51,7 @@ func NewConfig(mongoVersionStr string) (*Config, error) {
 		return nil, err
 	}
 
-	cachePath, err := buildBinCachePath(downloadUrl)
+	cachePath, err := buildBinCachePath(ctx, downloadUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -64,16 +64,16 @@ func NewConfig(mongoVersionStr string) (*Config, error) {
 }
 
 // buildBinCachePath returns the full path to where the mongod binary should be located.
-func buildBinCachePath(downloadUrl string) (string, error) {
+func buildBinCachePath(ctx context.Context, downloadUrl string) (string, error) {
 	cacheHome, err := defaultBaseCachePath()
 	if err != nil {
-		log.Error(context.Background(), "cache directory not found", err)
+		log.Error(ctx, "cache directory not found", err)
 		return "", err
 	}
 
 	urlParsed, err := url.Parse(downloadUrl)
 	if err != nil {
-		log.Error(context.Background(), "error parsing url", err, log.Data{"url": downloadUrl})
+		log.Error(ctx, "error parsing url", err, log.Data{"url": downloadUrl})
 		return "", err
 	}
 

--- a/download/config_test.go
+++ b/download/config_test.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -11,12 +12,13 @@ func TestNewConfig(t *testing.T) {
 	var originalGetDownloadUrl = getDownloadUrl
 	var originalGetEnv = getEnv
 	var originalGoOs = goOS
+	testCtx := context.Background()
 
 	Convey("Given an invalid MongoDB version", t, func() {
 		Convey("Without periods", func() {
 			version := "version"
 			Convey("Then an error is returned", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldBeError)
 				expectedError := &UnsupportedMongoVersionError{
@@ -30,7 +32,7 @@ func TestNewConfig(t *testing.T) {
 		Convey("With less than 2 periods", func() {
 			version := "1.2"
 			Convey("Then an error is returned", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldBeError)
 				expectedError := &UnsupportedMongoVersionError{
@@ -44,7 +46,7 @@ func TestNewConfig(t *testing.T) {
 		Convey("With more than 2 periods", func() {
 			version := "2.1.0.a"
 			Convey("Then an error is returned", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldBeError)
 				expectedError := &UnsupportedMongoVersionError{
@@ -58,7 +60,7 @@ func TestNewConfig(t *testing.T) {
 		Convey("With an invalid major version", func() {
 			version := "a.1.0"
 			Convey("Then an error is returned", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldBeError)
 				expectedError := &UnsupportedMongoVersionError{
@@ -72,7 +74,7 @@ func TestNewConfig(t *testing.T) {
 		Convey("With an invalid minor version", func() {
 			version := "4.minor.0"
 			Convey("Then an error is returned", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldBeError)
 				expectedError := &UnsupportedMongoVersionError{
@@ -86,7 +88,7 @@ func TestNewConfig(t *testing.T) {
 		Convey("With an invalid patch version", func() {
 			version := "4.7.pp"
 			Convey("Then an error is returned", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldBeError)
 				expectedError := &UnsupportedMongoVersionError{
@@ -100,7 +102,7 @@ func TestNewConfig(t *testing.T) {
 		Convey("With a non-supported old version", func() {
 			version := "4.2.15"
 			Convey("Then an error is returned", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldBeError)
 				expectedError := &UnsupportedMongoVersionError{
@@ -133,7 +135,7 @@ func TestNewConfig(t *testing.T) {
 						return ""
 					}
 					Convey("Then NewConfig uses the XDG_CACHE_HOME env var to determine the cache path", func() {
-						cfg, err := NewConfig(version)
+						cfg, err := NewConfig(testCtx, version)
 						So(err, ShouldBeNil)
 						So(cfg.mongoVersion.String(), ShouldEqual, version)
 						So(cfg.mongoUrl, ShouldEqual, mongoUrl)
@@ -151,7 +153,7 @@ func TestNewConfig(t *testing.T) {
 					Convey("And running on OSX", func() {
 						goOS = "darwin"
 						Convey("Then NewConfig determines the right home cache path", func() {
-							cfg, err := NewConfig(version)
+							cfg, err := NewConfig(testCtx, version)
 							So(err, ShouldBeNil)
 							So(cfg.mongoVersion.String(), ShouldEqual, version)
 							So(cfg.mongoUrl, ShouldEqual, mongoUrl)
@@ -161,7 +163,7 @@ func TestNewConfig(t *testing.T) {
 					Convey("And running on Linux", func() {
 						goOS = "linux"
 						Convey("Then NewConfig determines the right home cache path", func() {
-							cfg, err := NewConfig(version)
+							cfg, err := NewConfig(testCtx, version)
 							So(err, ShouldBeNil)
 							So(cfg.mongoVersion.String(), ShouldEqual, version)
 							So(cfg.mongoUrl, ShouldEqual, mongoUrl)
@@ -171,7 +173,7 @@ func TestNewConfig(t *testing.T) {
 					Convey("And running on Windows", func() {
 						goOS = "win32"
 						Convey("Then NewConfig errors", func() {
-							cfg, err := NewConfig(version)
+							cfg, err := NewConfig(testCtx, version)
 							So(cfg, ShouldBeNil)
 							So(err, ShouldBeError)
 							expectedError := &UnsupportedSystemError{msg: "OS 'win32'"}
@@ -190,7 +192,7 @@ func TestNewConfig(t *testing.T) {
 					return ":invalid", nil
 				}
 				Convey("Then NewConfig errors", func() {
-					cfg, err := NewConfig(version)
+					cfg, err := NewConfig(testCtx, version)
 					So(err, ShouldBeError)
 					So(cfg, ShouldBeNil)
 				})
@@ -210,7 +212,7 @@ func TestNewConfig(t *testing.T) {
 			}
 
 			Convey("Then NewConfig errors", func() {
-				cfg, err := NewConfig(version)
+				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)
 				So(err, ShouldEqual, expectedError)
 			})

--- a/main.go
+++ b/main.go
@@ -28,90 +28,86 @@ type Server struct {
 	port       int
 }
 
-func init() {
-	log.Namespace = "dp-mongodb-in-memory"
-}
-
 // Start runs a MongoDB server at a given version using a random free port
 // and returns the Server.
-func Start(version string) (*Server, error) {
+func Start(ctx context.Context, version string) (*Server, error) {
 	server := new(Server)
 
-	binPath, err := getOrDownloadBinPath(version)
+	binPath, err := getOrDownloadBinPath(ctx, version)
 	if err != nil {
-		log.Fatal(context.Background(), "Could not find mongodb", err)
+		log.Fatal(ctx, "Could not find mongodb", err)
 		return nil, err
 	}
 
 	// Create a db dir. Even the ephemeralForTest engine needs a dbpath.
 	server.dbDir, err = ioutil.TempDir("", "")
 	if err != nil {
-		log.Fatal(context.Background(), "Error creating data directory", err)
+		log.Fatal(ctx, "Error creating data directory", err)
 		return nil, err
 	}
 
-	log.Info(context.Background(), "Starting mongod server", log.Data{"binPath": binPath, "dbDir": server.dbDir})
+	log.Info(ctx, "Starting mongod server", log.Data{"binPath": binPath, "dbDir": server.dbDir})
 	// By specifying port 0, mongo will find and use an available port
 	server.cmd = exec.Command(binPath, "--storageEngine", "ephemeralForTest", "--dbpath", server.dbDir, "--port", "0")
 
 	startupErrCh := make(chan error)
 	startupPortCh := make(chan int)
-	stdHandler := stdHandler(startupPortCh, startupErrCh)
+	stdHandler := stdHandler(ctx, startupPortCh, startupErrCh)
 	server.cmd.Stdout = stdHandler
 	server.cmd.Stderr = stdHandler
 
 	// Run the server
 	err = server.cmd.Start()
 	if err != nil {
-		log.Fatal(context.Background(), "Could not start mongodb", err)
-		server.Stop()
+		log.Fatal(ctx, "Could not start mongodb", err)
+		server.Stop(ctx)
 		return nil, err
 	}
 
-	log.Info(context.Background(), "Starting watcher")
+	log.Info(ctx, "Starting watcher")
 	// Start a watcher: the watcher is a subprocess that ensures if this process
 	// dies, the mongo server will be killed (and not reparented under init)
 	server.watcherCmd, err = monitor.Run(os.Getpid(), server.cmd.Process.Pid)
 	if err != nil {
-		log.Error(context.Background(), "Could not start watcher", err)
-		server.Stop()
+		log.Error(ctx, "Could not start watcher", err)
+		server.Stop(ctx)
 		return nil, err
 	}
 
 	select {
 	case server.port = <-startupPortCh:
 	case err := <-startupErrCh:
-		server.Stop()
+		server.Stop(ctx)
 		return nil, err
 	case <-time.After(timeout):
-		server.Stop()
+		server.Stop(ctx)
 		return nil, errors.New("timed out waiting for mongod to start")
 	}
 
-	log.Info(context.Background(), fmt.Sprintf("mongod started up and reported port number %d", server.port))
+	log.Info(ctx, fmt.Sprintf("mongod started up and reported port number %d", server.port))
 
 	return server, nil
 }
 
 // Stop kills the mongo server.
-func (s *Server) Stop() {
+func (s *Server) Stop(ctx context.Context) {
 	if s.cmd != nil {
 		err := s.cmd.Process.Kill()
 		if err != nil {
-			log.Error(context.Background(), "Error stopping mongod process", err, log.Data{"pid": s.cmd.Process.Pid})
+			log.Error(ctx, "Error stopping mongod process", err, log.Data{"pid": s.cmd.Process.Pid})
 		}
 	}
 
 	if s.watcherCmd != nil {
 		err := s.watcherCmd.Process.Kill()
 		if err != nil {
-			log.Error(context.Background(), "error stopping watcher process", err, log.Data{"pid": s.watcherCmd.Process.Pid})
+			log.Error(ctx, "error stopping watcher process", err, log.Data{"pid": s.watcherCmd.Process.Pid})
 		}
 	}
 
 	err := os.RemoveAll(s.dbDir)
 	if err != nil {
-		log.Error(context.Background(), "Error removing data directory", err, log.Data{"dir": s.dbDir})
+		log.Error(ctx, "Error removing data directory", err, log.Data{"dir": s.dbDir})
 	}
 }
 
@@ -125,14 +121,14 @@ func (s *Server) URI() string {
 	return fmt.Sprintf("mongodb://localhost:%d", s.port)
 }
 
-func getOrDownloadBinPath(version string) (string, error) {
-	config, err := download.NewConfig(version)
+func getOrDownloadBinPath(ctx context.Context, version string) (string, error) {
+	config, err := download.NewConfig(ctx, version)
 	if err != nil {
-		log.Error(context.Background(), "Failed to create config", err)
+		log.Error(ctx, "Failed to create config", err)
 		return "", err
 	}
 
-	if err := download.GetMongoDB(*config); err != nil {
+	if err := download.GetMongoDB(ctx, *config); err != nil {
 		return "", err
 	}
 	return config.MongoPath(), nil
@@ -142,7 +138,7 @@ func getOrDownloadBinPath(version string) (string, error) {
 // It accepts 2 channels:
 // errCh will receive any error logged,
 // okCh will receive the port number if mongodb started successfully
-func stdHandler(okCh chan<- int, errCh chan<- error) io.Writer {
+func stdHandler(ctx context.Context, okCh chan<- int, errCh chan<- error) io.Writer {
 	reader, writer := io.Pipe()
 
 	go func() {
@@ -154,7 +150,7 @@ func stdHandler(okCh chan<- int, errCh chan<- error) io.Writer {
 			err := json.Unmarshal([]byte(text), &logMessage)
 			if err != nil {
 				// Output the message as is if not json
-				log.Info(context.Background(), fmt.Sprintf("[mongod] %s", text))
+				log.Info(ctx, fmt.Sprintf("[mongod] %s", text))
 			} else {
 				message := logMessage["msg"]
 				severity := logMessage["s"]
@@ -167,12 +163,12 @@ func stdHandler(okCh chan<- int, errCh chan<- error) io.Writer {
 					okCh <- int(attr["port"].(float64))
 				}
 
-				log.Info(context.Background(), fmt.Sprintf("[mongod] %s", message), logMessage)
+				log.Info(ctx, fmt.Sprintf("[mongod] %s", message), logMessage)
 			}
 		}
 
 		if err := scanner.Err(); err != nil {
-			log.Error(context.Background(), "reading mongod stdout/stderr failed: %s", err)
+			log.Error(ctx, "reading mongod stdout/stderr failed: %s", err)
 		}
 	}()
 

--- a/main_test.go
+++ b/main_test.go
@@ -13,12 +13,13 @@ import (
 
 func TestStart(t *testing.T) {
 	versions := []string{"4.4.8", "5.0.2"}
+	testCtx := context.Background()
 
 	for _, version := range versions {
 		Convey("Given the version "+version, t, func() {
 			Convey("When the Start method is called", func() {
-				server, err := Start(version)
-				defer server.Stop()
+				server, err := Start(testCtx, version)
+				defer server.Stop(testCtx)
 
 				Convey("Then no error is returned", func() {
 					So(err, ShouldBeNil)
@@ -49,10 +50,10 @@ func TestStart(t *testing.T) {
 						So(server.watcherCmd.Args[2], ShouldEqual, expectedScript)
 					})
 					Convey("And the server accepts connections", func() {
-						client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(server.URI()))
+						client, err := mongo.Connect(testCtx, options.Client().ApplyURI(server.URI()))
 						So(err, ShouldBeNil)
 						So(client, ShouldNotBeNil)
-						So(client.Ping(context.Background(), nil), ShouldBeNil)
+						So(client.Ping(testCtx, nil), ShouldBeNil)
 					})
 				})
 			})


### PR DESCRIPTION
### What

- Remove log.Namespace as this should be set by the application that is using this library
- Context should be passed as first variable into methods and functions that use it

### How to review

Check changes make sense and unit tests pass; `make test`

### Who can review

Anyone
