### PR TITLE
Support Manjaro (Arch Linux Distribution)

### DIFF
--- a/download/config.go
+++ b/download/config.go
@@ -22,14 +22,6 @@ var getDownloadUrl = func(v Version) (string, error) {
 	return spec.GetDownloadURL()
 }
 
-var detectLinuxId = func() (string, error) {
-	osName, err := DetectLinuxId()
-	if err != nil {
-		return "", err
-	}
-	return osName, nil
-}
-
 // getEnv returns the value of an environment variable
 var getEnv = func(key string) string {
 	return os.Getenv(key)
@@ -53,11 +45,11 @@ func NewConfig(ctx context.Context, mongoVersionStr string) (*Config, error) {
 	if versionErr != nil {
 		return nil, versionErr
 	}
-	osName, err := detectLinuxId()
+	downloadUrl, err := getDownloadUrl(*version)
 	if err != nil {
 		return nil, err
 	}
-	if osName == "manjaro" {
+	if downloadUrl == DoNotDownload {
 		basePath, err := defaultBaseCachePath()
 		if err != nil {
 			log.Error(ctx, "cache directory not found", err)
@@ -68,11 +60,6 @@ func NewConfig(ctx context.Context, mongoVersionStr string) (*Config, error) {
 			cachePath:    basePath + "/mongod",
 		}, nil
 	} else {
-		downloadUrl, err := getDownloadUrl(*version)
-		if err != nil {
-			return nil, err
-		}
-
 		cachePath, err := buildBinCachePath(ctx, downloadUrl)
 		if err != nil {
 			return nil, err

--- a/download/config_test.go
+++ b/download/config_test.go
@@ -101,6 +101,9 @@ func TestNewConfig(t *testing.T) {
 		})
 		Convey("With a non-supported old version", func() {
 			version := "4.2.15"
+			detectLinuxId = func() (string, error) {
+				return "ubuntu2004", nil
+			}
 			Convey("Then an error is returned", func() {
 				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)

--- a/download/config_test.go
+++ b/download/config_test.go
@@ -101,9 +101,6 @@ func TestNewConfig(t *testing.T) {
 		})
 		Convey("With a non-supported old version", func() {
 			version := "4.2.15"
-			detectLinuxId = func() (string, error) {
-				return "ubuntu2004", nil
-			}
 			Convey("Then an error is returned", func() {
 				cfg, err := NewConfig(testCtx, version)
 				So(cfg, ShouldBeNil)

--- a/download/downloadSpec.go
+++ b/download/downloadSpec.go
@@ -59,7 +59,7 @@ func MakeDownloadSpec(version Version) (*DownloadSpec, error) {
 		return nil, platformErr
 	}
 
-	osName, osErr := detectLinuxId()
+	osName, osErr := DetectLinuxId()
 	if osErr != nil {
 		return nil, osErr
 	}
@@ -122,7 +122,7 @@ func detectArch() (string, error) {
 	}
 }
 
-func detectLinuxId() (string, error) {
+func DetectLinuxId() (string, error) {
 	if goOS != "linux" {
 		// Not on Linux
 		return "", nil
@@ -141,6 +141,9 @@ func detectLinuxId() (string, error) {
 	}
 
 	id := osRelease["ID"]
+	if id == "manjaro" {
+		return "manjaro", nil
+	}
 	versionString := strings.Split(osRelease["VERSION_ID"], ".")[0]
 	version, versionErr := strconv.Atoi(versionString)
 	if versionErr != nil {

--- a/download/downloadSpec.go
+++ b/download/downloadSpec.go
@@ -18,6 +18,7 @@ const etcOsReleaseFileName = "/etc/os-release"
 
 var goOS = runtime.GOOS
 var goArch = runtime.GOARCH
+var DoNotDownload = "DO_NOT_DOWNLOAD"
 
 // DownloadSpec specifies what copy of MongoDB to download
 type DownloadSpec struct {
@@ -59,7 +60,7 @@ func MakeDownloadSpec(version Version) (*DownloadSpec, error) {
 		return nil, platformErr
 	}
 
-	osName, osErr := DetectLinuxId()
+	osName, osErr := detectLinuxId()
 	if osErr != nil {
 		return nil, osErr
 	}
@@ -79,6 +80,9 @@ func (spec *DownloadSpec) GetDownloadURL() (string, error) {
 
 	switch spec.Platform {
 	case "linux":
+		if spec.OSName == "manjaro" {
+			return DoNotDownload, nil
+		}
 		if spec.OSName == "" {
 			return "", fmt.Errorf("invalid spec: OS name not provided")
 		}
@@ -122,7 +126,7 @@ func detectArch() (string, error) {
 	}
 }
 
-func DetectLinuxId() (string, error) {
+func detectLinuxId() (string, error) {
 	if goOS != "linux" {
 		// Not on Linux
 		return "", nil
@@ -141,13 +145,14 @@ func DetectLinuxId() (string, error) {
 	}
 
 	id := osRelease["ID"]
-	if id == "manjaro" {
-		return "manjaro", nil
-	}
-	versionString := strings.Split(osRelease["VERSION_ID"], ".")[0]
-	version, versionErr := strconv.Atoi(versionString)
-	if versionErr != nil {
-		return "", &UnsupportedSystemError{msg: "invalid version number " + versionString}
+	versionString := osRelease["VERSION_ID"]
+	version := 0
+	if versionString != "" {
+		var versionErr error
+		version, versionErr = strconv.Atoi(strings.Split(versionString, ".")[0])
+		if versionErr != nil {
+			return "", &UnsupportedSystemError{msg: "invalid version number " + versionString}
+		}
 	}
 	switch id {
 	case "ubuntu":
@@ -161,6 +166,8 @@ func DetectLinuxId() (string, error) {
 			return "ubuntu1604", nil
 		}
 		return "", &UnsupportedSystemError{msg: "invalid ubuntu version " + versionString + " (min 16)"}
+	case "manjaro":
+		return "manjaro", nil
 	case "debian":
 		if version >= 10 {
 			return "debian10", nil

--- a/download/downloadSpec_test.go
+++ b/download/downloadSpec_test.go
@@ -161,7 +161,7 @@ func TestMakeDownloadSpec(t *testing.T) {
 					"Old Ubuntu": {
 						linuxId:      "ubuntu",
 						linuxVersion: "14.04",
-						expectedErr:  &UnsupportedSystemError{msg: "invalid ubuntu version 14 (min 16)"},
+						expectedErr:  &UnsupportedSystemError{msg: "invalid ubuntu version 14.04 (min 16)"},
 					},
 					"Debian 10": {
 						linuxId:      "debian",
@@ -186,7 +186,7 @@ func TestMakeDownloadSpec(t *testing.T) {
 					"Old Debian": {
 						linuxId:      "debian",
 						linuxVersion: "8.1",
-						expectedErr:  &UnsupportedSystemError{msg: "invalid debian version 8 (min 9)"},
+						expectedErr:  &UnsupportedSystemError{msg: "invalid debian version 8.1 (min 9)"},
 					},
 					"Other Linux": {
 						linuxId:      "fedora",

--- a/download/downloadSpec_test.go
+++ b/download/downloadSpec_test.go
@@ -109,6 +109,15 @@ func TestMakeDownloadSpec(t *testing.T) {
 					expectedSpec *DownloadSpec
 					expectedErr  error
 				}{
+					"Manjaro": {
+						linuxId: "manjaro",
+						expectedSpec: &DownloadSpec{
+							version:  &version,
+							Arch:     "x86_64",
+							Platform: "linux",
+							OSName:   "manjaro",
+						},
+					},
 					"Ubuntu 20.04": {
 						linuxId:      "ubuntu",
 						linuxVersion: "20.04",


### PR DESCRIPTION
### What
[memongo](https://github.com/benweissmann/memongo#caveats-and-notes), [dp-mongo-in-memory](https://github.com/ONSdigital/dp-mongodb-in-memory#supported-versions) and [MongoDB](https://www.mongodb.com/download-center/community/releases) do not support Arch/Manjaro distribution, so this is an attempt to support a [Manjaro](https://manjaro.org/) distribution.

This avoids having to download the MongoDBSpec and assumes the user has a working `mongod` daemon working on the expected `CachedPath`. It makes use of the `XDG_CACHE_HOME` environment variable.


### How to review

Run locally, namely Ubuntu and Mac OS'.

### Who can review

@rafahop & @saminahbab you are probably the best folks to review this :) 
