### PR TITLE
Added support for Amazon Linux 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following Unix systems are supported:
 - MacOS
 - Ubuntu 16.04 or greater
 - Debian 9.2 or greater
+- Amazon Linux 2
 
 The supported MongoDB versions are 4.4 and above.
 

--- a/download/downloadSpec.go
+++ b/download/downloadSpec.go
@@ -36,6 +36,7 @@ type DownloadSpec struct {
 	// - ubuntu1604
 	// - debian10
 	// - debian92
+	// - amazon2
 	// - "" for MacOS
 	OSName string
 }
@@ -166,6 +167,11 @@ func detectLinuxId() (string, error) {
 			return "debian92", nil
 		}
 		return "", &UnsupportedSystemError{msg: "invalid debian version " + versionString + " (min 9)"}
+	case "amzn":
+		if version == 2 {
+			return "amazon2", nil
+		}
+		return "", &UnsupportedSystemError{msg: "invalid amazon linux version " + versionString + " (only 2)"}
 	default:
 		return "", &UnsupportedSystemError{msg: "invalid linux version '" + id + "'"}
 	}

--- a/download/downloadSpec_test.go
+++ b/download/downloadSpec_test.go
@@ -179,6 +179,21 @@ func TestMakeDownloadSpec(t *testing.T) {
 						linuxVersion: "8.1",
 						expectedErr:  &UnsupportedSystemError{msg: "invalid debian version 8 (min 9)"},
 					},
+					"Amazon Linux 2": {
+						linuxId:      "amzn",
+						linuxVersion: "2",
+						expectedSpec: &DownloadSpec{
+							version:  &version,
+							Arch:     "x86_64",
+							Platform: "linux",
+							OSName:   "amazon2",
+						},
+					},
+					"Old Amazon Linux": {
+						linuxId:      "amzn",
+						linuxVersion: "1",
+						expectedErr:  &UnsupportedSystemError{msg: "invalid amazon linux version 1 (only 2)"},
+					},
 					"Other Linux": {
 						linuxId:      "fedora",
 						linuxVersion: "17",


### PR DESCRIPTION
### What

Added support for using this library on a machine with Amazon Linux 2.  This is a common OS for EC2 machines in AWS.  MongoDB supports this OS so it just means choosing the correct OS name when downloading the Mongo binary.  Tests have been expanded to cover this OS. 

### How to review

To test the changes, a machine running Amazon Linux 2 is required, for instance using an AWS EC2.  I've tested this and confirm it works.

### Who can review

Anyone
